### PR TITLE
Integrate Qwen3 embedding

### DIFF
--- a/api/config/embedder_qwen.json
+++ b/api/config/embedder_qwen.json
@@ -1,0 +1,23 @@
+{
+  "embedder": {
+    "client_class": "QwenClient",
+    "initialize_kwargs": {
+      "api_key": "${DASHSCOPE_API_KEY}",
+      "base_url": "${DASHSCOPE_BASE_URL}"
+    },
+    "batch_size": 10,
+    "model_kwargs": {
+      "model": "text-embedding-v4",
+      "dimensions": 1024,
+      "encoding_format": "float"
+    }
+  },
+  "retriever": {
+    "top_k": 20
+  },
+  "text_splitter": {
+    "split_by": "word",
+    "chunk_size": 350,
+    "chunk_overlap": 100
+  }
+}

--- a/api/qwen_embedding_example.py
+++ b/api/qwen_embedding_example.py
@@ -1,0 +1,25 @@
+"""Example script to generate embeddings using Alibaba Qwen3 model via DashScope."""
+
+import os
+from openai import OpenAI
+
+# Initialize the OpenAI client with DashScope credentials
+client = OpenAI(
+    api_key=os.getenv("DASHSCOPE_API_KEY"),
+    base_url=os.getenv("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+)
+
+if __name__ == "__main__":
+    response = client.embeddings.create(
+        model="text-embedding-v4",
+        input=[
+            "风急天高猿啸哀",
+            "渚清沙白鸟飞回",
+            "无边落木萧萧下",
+            "不尽长江滚滚来",
+        ],
+        dimensions=1024,
+        encoding_format="float",
+    )
+    print(response.model_dump_json())
+


### PR DESCRIPTION
## Summary
- add config for Qwen3 `text-embedding-v4`
- example script showing how to call DashScope embedding API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bee8e34f8833194f1aa97e018a0c1