### PR TITLE
Fix Dashscope async streaming

### DIFF
--- a/api/dashscope_client.py
+++ b/api/dashscope_client.py
@@ -503,17 +503,16 @@ class DashscopeClient(ModelClient):
             self.async_client = self.init_async_client()
 
         if model_type == ModelType.LLM:
-            if not api_kwargs.get("stream", False):
+            if api_kwargs.get("stream", False):
+                completion = await self.async_client.chat.completions.create(**api_kwargs)
+                return completion  # return the async stream
+            else:
                 # For non-streaming, enable_thinking must be false.
                 extra_body = api_kwargs.get("extra_body", {})
                 extra_body["enable_thinking"] = False
                 api_kwargs["extra_body"] = extra_body
 
-            completion = await self.async_client.chat.completions.create(**api_kwargs)
-
-            if api_kwargs.get("stream", False):
-                return handle_streaming_response(completion)
-            else:
+                completion = await self.async_client.chat.completions.create(**api_kwargs)
                 return self.parse_chat_completion(completion)
         elif model_type == ModelType.EMBEDDER:
             # Extract input texts from api_kwargs

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -717,12 +717,13 @@ This file contains...
                     )
                     # Handle streaming response from Dashscope
                     async for chunk in response:
-                        text = (
-                            chunk
-                            if isinstance(chunk, str)
-                            else getattr(chunk, "text", str(chunk))
-                        )
-                        await websocket.send_text(text)
+                        choices = getattr(chunk, "choices", [])
+                        if len(choices) > 0:
+                            delta = getattr(choices[0], "delta", None)
+                            if delta is not None:
+                                text = getattr(delta, "content", None)
+                                if text is not None:
+                                    await websocket.send_text(text)
                     # Explicitly close the WebSocket connection after the response is complete
                     await websocket.close()
                 except Exception as e_dashscope:
@@ -897,12 +898,13 @@ This file contains...
 
                             # Handle streaming fallback response from Dashscope
                             async for chunk in fallback_response:
-                                text = (
-                                    chunk
-                                    if isinstance(chunk, str)
-                                    else getattr(chunk, "text", str(chunk))
-                                )
-                                await websocket.send_text(text)
+                                choices = getattr(chunk, "choices", [])
+                                if len(choices) > 0:
+                                    delta = getattr(choices[0], "delta", None)
+                                    if delta is not None:
+                                        text = getattr(delta, "content", None)
+                                        if text is not None:
+                                            await websocket.send_text(text)
                         except Exception as e_fallback:
                             logger.error(
                                 f"Error with Dashscope API fallback: {str(e_fallback)}"


### PR DESCRIPTION
## Summary
- return async stream directly from `DashscopeClient.acall`
- parse Dashscope streaming chunks in websocket handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f877ebcc83318d5e6bbd23a72434