### PR TITLE
feat: add dashscope provider

### DIFF
--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -17,6 +17,7 @@ from api.openai_client import OpenAIClient
 from api.openrouter_client import OpenRouterClient
 from api.bedrock_client import BedrockClient
 from api.azureai_client import AzureAIClient
+from api.dashscope_client import DashscopeClient
 from api.rag import RAG
 
 # Configure logging
@@ -57,7 +58,10 @@ class ChatCompletionRequest(BaseModel):
     type: Optional[str] = Field("github", description="Type of repository (e.g., 'github', 'gitlab', 'bitbucket')")
 
     # model parameters
-    provider: str = Field("google", description="Model provider (google, openai, openrouter, ollama, bedrock, azure)")
+    provider: str = Field(
+        "google",
+        description="Model provider (google, openai, openrouter, ollama, bedrock, azure, dashscope)",
+    )
     model: Optional[str] = Field(None, description="Model name for the specified provider")
 
     language: Optional[str] = Field("en", description="Language for content generation (e.g., 'en', 'ja', 'zh', 'es', 'kr', 'vi')")
@@ -529,16 +533,30 @@ This file contains...
                 model_kwargs=model_kwargs,
                 model_type=ModelType.LLM
             )
-        else:
+        elif request.provider == "dashscope":
+            logger.info(f"Using Dashscope with model: {request.model}")
+            model = DashscopeClient()
+            model_kwargs = {
+                "model": request.model,
+                "stream": True,
+                "temperature": model_config["temperature"],
+                "top_p": model_config["top_p"],
+            }
+            api_kwargs = model.convert_inputs_to_api_kwargs(
+                input=prompt, model_kwargs=model_kwargs, model_type=ModelType.LLM
+            )
+        elif request.provider == "google":
             # Initialize Google Generative AI model
             model = genai.GenerativeModel(
                 model_name=model_config["model"],
                 generation_config={
                     "temperature": model_config["temperature"],
                     "top_p": model_config["top_p"],
-                    "top_k": model_config["top_k"]
-                }
+                    "top_k": model_config["top_k"],
+                },
             )
+        else:
+            raise HTTPException(status_code=400, detail=f"Unsupported provider: {request.provider}")
 
         # Create a streaming response
         async def response_stream():
@@ -611,13 +629,32 @@ This file contains...
                     except Exception as e_azure:
                         logger.error(f"Error with Azure AI API: {str(e_azure)}")
                         yield f"\nError with Azure AI API: {str(e_azure)}\n\nPlease check that you have set the AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and AZURE_OPENAI_VERSION environment variables with valid values."
-                else:
+                elif request.provider == "dashscope":
+                    try:
+                        # Get the response and handle it properly using the previously created api_kwargs
+                        logger.info("Making Dashscope API call")
+                        response = await model.acall(api_kwargs=api_kwargs, model_type=ModelType.LLM)
+                        # Handle streaming response from Dashscope
+                        async for chunk in response:
+                            choices = getattr(chunk, "choices", [])
+                            if len(choices) > 0:
+                                delta = getattr(choices[0], "delta", None)
+                                if delta is not None:
+                                    text = getattr(delta, "content", None)
+                                    if text is not None:
+                                        yield text
+                    except Exception as e_dashscope:
+                        logger.error(f"Error with Dashscope API: {str(e_dashscope)}")
+                        yield f"\nError with Dashscope API: {str(e_dashscope)}\n\nPlease check that you have set the DASHSCOPE_API_KEY environment variable with a valid API key."
+                elif request.provider == "google":
                     # Generate streaming response
                     response = model.generate_content(prompt, stream=True)
                     # Stream the response
                     for chunk in response:
                         if hasattr(chunk, 'text'):
                             yield chunk.text
+                else:
+                    raise HTTPException(status_code=400, detail=f"Unsupported provider: {request.provider}")
 
             except Exception as e_outer:
                 logger.error(f"Error in streaming response: {str(e_outer)}")
@@ -745,7 +782,32 @@ This file contains...
                             except Exception as e_fallback:
                                 logger.error(f"Error with Azure AI API fallback: {str(e_fallback)}")
                                 yield f"\nError with Azure AI API fallback: {str(e_fallback)}\n\nPlease check that you have set the AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and AZURE_OPENAI_VERSION environment variables with valid values."
-                        else:
+                        elif request.provider == "dashscope":
+                            try:
+                                # Create new api_kwargs with the simplified prompt
+                                fallback_api_kwargs = model.convert_inputs_to_api_kwargs(
+                                    input=simplified_prompt,
+                                    model_kwargs=model_kwargs,
+                                    model_type=ModelType.LLM
+                                )
+
+                                # Get the response using the simplified prompt
+                                logger.info("Making fallback Dashscope API call")
+                                fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
+
+                                # Handle streaming fallback response from Dashscope
+                                async for chunk in fallback_response:
+                                    choices = getattr(chunk, "choices", [])
+                                    if len(choices) > 0:
+                                        delta = getattr(choices[0], "delta", None)
+                                        if delta is not None:
+                                            text = getattr(delta, "content", None)
+                                            if text is not None:
+                                                yield text
+                            except Exception as e_fallback:
+                                logger.error(f"Error with Dashscope API fallback: {str(e_fallback)}")
+                                yield f"\nError with Dashscope API fallback: {str(e_fallback)}\n\nPlease check that you have set the DASHSCOPE_API_KEY environment variable with a valid API key."
+                        elif request.provider == "google":
                             # Initialize Google Generative AI model
                             model_config = get_model_config(request.provider, request.model)
                             fallback_model = genai.GenerativeModel(
@@ -763,6 +825,8 @@ This file contains...
                             for chunk in fallback_response:
                                 if hasattr(chunk, 'text'):
                                     yield chunk.text
+                        else:
+                            raise HTTPException(status_code=400, detail=f"Unsupported provider: {request.provider}")
                     except Exception as e2:
                         logger.error(f"Error in fallback streaming response: {str(e2)}")
                         yield f"\nI apologize, but your request is too large for me to process. Please try a shorter query or break it into smaller parts."


### PR DESCRIPTION
## Summary
- extend chat API with Dashscope client and provider option
- add Dashscope-specific streaming and fallback handling
- restrict Google branch and error on unsupported providers

## Testing
- `pytest`
- manual Dashscope API kwargs generation to ensure no Google fallback

------
https://chatgpt.com/codex/tasks/task_e_6890b029cc2c8331a915df17b7d47753